### PR TITLE
Basic Build to spit out initrd and kernel as release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,36 @@
+sudo: true
+
+language: bash
+
+services:
+  - docker
+
+env:
+  global:
+    - DEBIAN_FRONTEND="noninteractive"
+
+jobs:
+  include:
+    - stage: Build and deploy
+      if: (NOT (type IN (pull_request))) AND (tag IS blank)
+      script:
+        # Build image to create custom initrd
+        - export KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}')
+        - docker build --no-cache -f Dockerfile --build-arg KERNEL_VERSION=${KERNEL_VERSION} -t kernel .
+        # Build the release contents
+        - mkdir -p buildout
+        - docker run --rm -it -v $(pwd)/buildout:/buildout kernel
+      before_deploy:
+        # Set up git user name and tag this commit
+        - git config --local user.name $GIT_USERNAME
+        - git config --local user.email $GIT_EMAIL
+        - export TRAVIS_TAG=${KERNEL_VERSION}-$(echo ${TRAVIS_COMMIT} | cut -c1-8)-${TRAVIS_JOB_NUMBER}
+        - git tag $TRAVIS_TAG
+      deploy:
+        provider: releases
+        api_key: $GITHUB_TOKEN
+        file_glob: true
+        file: buildout/*
+        skip_cleanup: true
+        on:
+          branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM ubuntu:bionic
+
+# versioning
+ARG KERNEL_VERSION
+
+# environment settings
+ARG DEBIAN_FRONTEND="noninteractive"
+ENV XDG_CONFIG_HOME="/config/xdg"
+
+# add local files
+COPY /root /
+
+RUN \
+ echo "**** install deps ****" && \
+ apt-get update && \
+ apt-get install -y \
+	casper \
+	curl \
+	initramfs-tools \
+	p7zip-full \
+	patch \
+	pixz \
+	psmisc \
+	wget && \
+ echo "**** patch casper ****" && \
+ patch /usr/share/initramfs-tools/scripts/casper < /patch && \
+ echo "**** install kernel ****" && \
+ if [ -z ${KERNEL_VERSION+x} ]; then \
+	KERNEL_VERSION=$(curl -sX GET http://archive.ubuntu.com/ubuntu/dists/bionic/main/binary-amd64/Packages.gz | gunzip -c |grep -A 7 -m 1 "Package: linux-image-virtual" | awk -F ": " '/Version/{print $2;exit}');\
+ fi && \
+ apt-get install -y \
+	linux-image-virtual=${KERNEL_VERSION} && \
+ echo "**** clean up ****" && \
+ mkdir /buildout && \
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
+
+ENTRYPOINT [ "/build.sh" ]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This is not a completed project it is only meant to illustrate a POC of building ISO contents into something that can be booted via HTTP.
+# Do not use

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-
+This is not a completed project it is only meant to illustrate a POC of building ISO contents into something that can be booted via HTTP.

--- a/root/build.sh
+++ b/root/build.sh
@@ -1,0 +1,8 @@
+#! /bin/bash
+
+# Copy initrd and kernel
+mv /boot/initrd.img-* /buildout/initrd
+mv /boot/vmlinuz-* /buildout/vmlinuz
+chmod 777 /buildout/*
+
+exit 0

--- a/root/patch
+++ b/root/patch
@@ -1,0 +1,54 @@
+--- scripts/casper.orig 2016-10-05 19:07:11.000000000 +0200
++++ scripts/casper      2016-10-05 19:26:58.000000000 +0200
+@@ -33,6 +33,10 @@ fi
+ parse_cmdline() {
+     for x in $(cat /proc/cmdline); do
+         case $x in
++            netboot=*)
++                export NETBOOT="${x#netboot=}";;
++            fetch=*)
++                export URL="${x#fetch=}";;
+             showmounts|show-cow)
+                 export SHOWMOUNTS='Yes' ;;
+             persistent)
+@@ -212,20 +216,31 @@ do_netmount() {
+         NFSROOT=${ROOTSERVER}:${ROOTPATH}
+     fi
+ 
+-    [ "$quiet" != "y" ] && log_begin_msg "Trying netboot from ${NFSROOT}"
+-
+-    if [ "${NETBOOT}" != "nfs" ] && do_cifsmount ; then
+-        rc=0
+-    elif do_nfsmount ; then
+-        NETBOOT="nfs"
+-        export NETBOOT
+-        rc=0
+-    fi
++    case ${NETBOOT} in
++        nfs)
++            [ "$quiet" != "y" ] && log_begin_msg "Trying netboot from ${NFSROOT}"
++            if do_nfsmount ; then rc=0; fi     ;;
++        cifs)
++            [ "$quiet" != "y" ] && log_begin_msg "Trying netboot from ${NFSROOT}"
++            if do_cifsmount ; then rc=0; fi ;;
++        http)
++            [ "$quiet" != "y" ] && log_begin_msg "Trying netboot from ${URL}"
++            if do_httpmount ; then rc=0; fi ;;
++    esac
+ 
+     [ "$quiet" != "y" ] && log_end_msg
+     return ${rc}
+ }
+ 
++do_httpmount() {
++    rc=1
++    mkdir -p ${mountpoint}
++    mount -t tmpfs -o size=`/bin/wget ${URL} --spider --server-response -O - 2>&1 | sed -ne '/Content-Length/{s/.*: //;p}'` tmpfs ${mountpoint}
++    mkdir -p ${mountpoint}/casper
++    if /bin/wget --progress=bar:force:noscroll ${URL} -O ${mountpoint}/casper/root.squashfs; then rc=0; fi
++    return ${rc}
++}
++
+ do_nfsmount() {
+     rc=1
+     modprobe "${MP_QUIET}" nfs

--- a/root/usr/share/initramfs-tools/hooks/wget
+++ b/root/usr/share/initramfs-tools/hooks/wget
@@ -1,0 +1,25 @@
+#!/bin/sh -e
+## required header
+PREREQS=""
+case $1 in
+        prereqs) echo "${PREREQS}"; exit 0;;
+esac
+. /usr/share/initramfs-tools/hook-functions
+
+## add wget from bionic install
+copy_exec /usr/bin/wget /bin
+
+## copy ssl certs
+mkdir -p \
+	$DESTDIR/etc/ssl \
+	$DESTDIR/usr/share/ca-certificates/
+cp -a \
+	/etc/ssl/certs \
+	$DESTDIR/etc/ssl/
+cp -a \
+	/etc/ca-certificates \
+	$DESTDIR/etc/
+cp -a \
+	/usr/share/ca-certificates/mozilla \
+	$DESTDIR/usr/share/ca-certificates/
+echo "ca_directory=/etc/ssl/certs" > $DESTDIR/etc/wgetrc


### PR DESCRIPTION
This does not include logic we need to discuss and build for triggering upstream. 

For this to work with travis we need a bot user and auth key capable of generating releases with the following Travis secrets set: 

GITHUB_TOKEN
GIT_USERNAME
GIT_EMAIL

To do stuff off the top of my head down the line: 
- template the build logic and the documentation in these repos as a travis build step 
- determine how to push this new release upstream to build a new release there with the new reference files (my attempts to have a local yaml in this repo and be able to merge it into something upstream to generate new menus failed some basic smoke tests, need to brainstorm something) 